### PR TITLE
Add Jacoco to Gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ jdk:
 script:
   - ./gradlew clean build test
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,8 +84,8 @@ tasks {
             html.isEnabled = true
             csv.isEnabled = false
 
-            xml.destination = file("$buildDir/reports/jacoco.xml")
-            html.destination = file("$buildDir/reports/jacocoHtml")
+            xml.destination = file("$buildDir/reports/jacoco/report.xml")
+            html.destination = file("$buildDir/reports/jacoco/jacocoHtml")
         }
 
         val matching = sourceSets.main.get().output.asFileTree.matching {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,11 +3,13 @@ plugins {
     kotlin("kapt") version "1.3.72"
     kotlin("plugin.spring") version "1.3.72"
 
+    jacoco
     id("org.springframework.boot") version "2.3.0.RELEASE"
     id("io.spring.dependency-management") version "1.0.9.RELEASE"
 
     id("org.jlleitschuh.gradle.ktlint") version "9.2.1"
     id("io.gitlab.arturbosch.detekt") version "1.9.1"
+    id("com.adarshr.test-logger") version "2.0.0"
 }
 
 group = "com.hxdcml.stockt"
@@ -45,6 +47,7 @@ dependencies {
 
     testImplementation(group = "org.springframework.boot", name = "spring-boot-starter-test")
 
+    testImplementation(kotlin("test-junit5"))
     testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.6.2")
     testRuntimeOnly(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.6.2")
 
@@ -66,5 +69,29 @@ tasks {
 
     test {
         useJUnitPlatform()
+    }
+
+    jacoco {
+        toolVersion = "0.8.5"
+        reportsDir = file("$buildDir/reports/jacoco")
+    }
+
+    jacocoTestReport {
+        group = "reporting"
+
+        reports {
+            xml.isEnabled = true
+            html.isEnabled = true
+            csv.isEnabled = false
+
+            xml.destination = file("$buildDir/reports/jacoco.xml")
+            html.destination = file("$buildDir/reports/jacocoHtml")
+        }
+
+        val matching = sourceSets.main.get().output.asFileTree.matching {
+            exclude("**/config/**", "**/Application*.*")
+        }
+
+        classDirectories.setFrom(matching)
     }
 }

--- a/src/test/kotlin/com/hxdcml/stockt/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/hxdcml/stockt/controller/UserControllerTest.kt
@@ -1,0 +1,29 @@
+package com.hxdcml.stockt.controller
+
+import com.hxdcml.stockt.model.request.CreateUserRequest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.junit.jupiter.MockitoExtension
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("User Controller")
+internal class UserControllerTest {
+
+    @InjectMocks
+    private lateinit var controller: UserController
+
+    @Test
+    @DisplayName("Create will accept valid payload and return valid response")
+    fun testCreateOnValidPayload() {
+        val request = CreateUserRequest(name = "John", age = 21)
+        val response = controller.createUser(request)
+
+        assertNotNull(response)
+        assertEquals("OK", response.status)
+        assertEquals("_placeholder_", response.id)
+    }
+}

--- a/src/test/kotlin/com/hxdcml/stockt/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/hxdcml/stockt/controller/UserControllerTest.kt
@@ -1,13 +1,13 @@
 package com.hxdcml.stockt.controller
 
 import com.hxdcml.stockt.model.request.CreateUserRequest
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.junit.jupiter.MockitoExtension
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 @ExtendWith(MockitoExtension::class)
 @DisplayName("User Controller")


### PR DESCRIPTION
Add Jacoco support to Gradle project.

Coverage can be produced by invoking the gradle command

> ./gradlew test jacocoTestReport